### PR TITLE
Sage and email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,5 +86,6 @@ group :test, :darwin do
   gem 'guard-rspec', '~> 4.5.2'
   gem 'rb-fsevent', '~> 0.9.5'
   gem 'factory_girl_rails', '~> 4.5.0'
+  gem 'timecop', '~> 0.8.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timecop (0.8.0)
     timers (4.0.1)
       hitimes
     turbolinks (2.5.3)
@@ -312,6 +313,7 @@ DEPENDENCIES
   spring-commands-rspec (~> 1.0.4)
   squeel (~> 1.2)
   sucker_punch (~> 1.5.1)
+  timecop (~> 0.8.0)
   turbolinks
   uglifier (>= 1.3.0)
   unobtrusive_flash (~> 3.1.0)

--- a/app/cells/post/form.erb
+++ b/app/cells/post/form.erb
@@ -16,8 +16,8 @@
     <%= f.text_field :author %>
   </div>
   <div class="field">
-    <%= f.label :email %>
-    <%= f.text_field :email %>
+    <%= f.label :options_raw %>
+    <%= f.text_field :options_raw %>
   </div>
   <%= render_cell :post, :image_upload_control, f %>
   <%= f.label :content %>

--- a/app/cells/post/show.erb
+++ b/app/cells/post/show.erb
@@ -1,7 +1,7 @@
 <article class="post" data-pos="<%= @post.pos %>">
   <header class="info">
-    <% if @post.email %>
-      <%= mail_to @post.email do %>
+    <% if @post.options_raw %>
+      <%= mail_to @post.options_raw do %>
         <span class="author"><%= @post.author || "anonymous" %></span>
       <% end %>
     <% else %>

--- a/app/lib/raw_options_analyzer.rb
+++ b/app/lib/raw_options_analyzer.rb
@@ -1,0 +1,25 @@
+class RawOptionsAnalyzer
+  # @param text [String] raw option text to be analyzed
+  # @param available_options [Array<String>] allowed options
+  # @return [String, nil]
+  def initialize(text, allowed_options)
+    text ||= ''
+    @text = text
+    @allowed_options = allowed_options
+    @tokens = text.split(' ')
+  end
+
+  # @return [String, nil]
+  def email
+    if @text.include?('@') # possible email
+      email = @tokens.find do |token|
+        token.match(/^\S+@\S+\.\S+$/)
+      end
+    end
+  end
+
+  # @return [Array<String>]
+  def options
+    @tokens & @allowed_options
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -44,6 +44,11 @@ class Post < ActiveRecord::Base
     topic.bump
   end
 
+  after_create :increment_topic_pos
+  def increment_topic_pos
+    topic.increment_pos
+  end
+
 private
 
   # Load post option modules to object's eigenclass.

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,6 +4,8 @@ class Post < ActiveRecord::Base
   belongs_to :topic, inverse_of: :posts
   has_many :images, inverse_of: :post, dependent: :destroy
 
+  serialize :options, Array
+
   nilify_blanks
 
   auto_html_for :content do

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,11 +16,21 @@ class Post < ActiveRecord::Base
     simple_format
   end
 
+  delegate :board, to: :topic
+
   validate :validate_content
   def validate_content
     if images.blank? && content.blank?
       errors.add(:base, 'Image or content is required')
     end
+  end
+
+  def options_raw=(value)
+    super
+
+    analyzer = RawOptionsAnalyzer.new(options_raw, board.config.post.allowed_options)
+    self.email = analyzer.email
+    self.options = analyzer.options
   end
 
   before_create :set_pos

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,6 +31,7 @@ class Post < ActiveRecord::Base
     analyzer = RawOptionsAnalyzer.new(options_raw, board.config.post.allowed_options)
     self.email = analyzer.email
     self.options = analyzer.options
+    extend_options
   end
 
   before_create :set_pos
@@ -41,5 +42,16 @@ class Post < ActiveRecord::Base
   after_create :bump_topic
   def bump_topic
     topic.bump
+  end
+
+private
+
+  # Load post option modules to object's eigenclass.
+  # This extends single object instance.
+  def extend_options
+    options.each do |option|
+      klass = Post::Extension.const_get(option.camelize)
+      self.extend klass
+    end
   end
 end

--- a/app/models/post/extension/sage.rb
+++ b/app/models/post/extension/sage.rb
@@ -1,0 +1,7 @@
+# Skip topic bump
+module Post::Extension::Sage
+  def bump_topic
+    # NOOP
+  end
+end
+

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -19,6 +19,11 @@ class Topic < ActiveRecord::Base
     update_columns(
       updated_at: now,
       bumped_at: now,
+    )
+  end
+
+  def increment_pos
+    update_columns(
       max_pos: max_pos + 1
     )
   end

--- a/app/services/post_form.rb
+++ b/app/services/post_form.rb
@@ -3,7 +3,7 @@ class PostForm
 
   attr_accessor :topic, :post
   delegate :title, :board_id, to: :topic
-  delegate :author, :content, :email, :topic_id, :images, :images_attributes=, to: :post
+  delegate :author, :content, :options_raw, :topic_id, :images, :images_attributes=, to: :post
 
   # To be called right after new().
   # For rendering empty form.
@@ -104,7 +104,7 @@ class PostForm
   end
 
   def post_params(params)
-    params.permit(:author, :content, :email, :topic_id)
+    params.permit(:author, :content, :options_raw, :topic_id)
   end
 
   def image_params(params)

--- a/config/app_config.yml.example
+++ b/config/app_config.yml.example
@@ -24,3 +24,6 @@ board:
     selector_options:
     remover_class: DestroyRemover
     remover_options:
+  post:
+    allowed_options:
+      - sage

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    attributes:
+      post:
+        options_raw: Email

--- a/db/migrate/20151006130931_add_options_to_posts.rb
+++ b/db/migrate/20151006130931_add_options_to_posts.rb
@@ -1,0 +1,13 @@
+class AddOptionsToPosts < ActiveRecord::Migration
+  def up
+    add_column :posts, :options, :string, after: :author, comment:'array of options like sage'
+    add_column :posts, :options_raw, :string, after: :options, comment:'user input for email and options'
+    execute 'UPDATE posts SET options_raw = email, email = NULL'
+  end
+
+  def down
+    execute 'UPDATE posts SET email = options_raw'
+    remove_column :posts, :options
+    remove_column :posts, :options_raw
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150715151825) do
+ActiveRecord::Schema.define(version: 20151006130931) do
 
   create_table "boards", force: :cascade, comment: "board" do |t|
     t.string   "seo_name",   limit: 255,   null: false, comment: "represent name in URL. Must be URL valid characters."
@@ -35,6 +35,8 @@ ActiveRecord::Schema.define(version: 20150715151825) do
   create_table "posts", force: :cascade, comment: "text content posted. New post or reply comments are all posts." do |t|
     t.text     "content",      limit: 65535,              comment: "text content"
     t.string   "author",       limit: 255,                comment: "author name"
+    t.string   "options",      limit: 255,                comment: "array of options like sage"
+    t.string   "options_raw",  limit: 255,                comment: "user input for email and options"
     t.string   "email",        limit: 255,                comment: "email"
     t.integer  "topic_id",     limit: 4,     null: false
     t.integer  "pos",          limit: 2,     null: false, comment: "position of post within topic"

--- a/spec/lib/raw_options_analyzer_spec.rb
+++ b/spec/lib/raw_options_analyzer_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe RawOptionsAnalyzer do
+  describe '#email' do
+    it "extracts single email" do
+      described_class.new("foobar@example.com", []).email.should == "foobar@example.com"
+      described_class.new("232323232323@BLUERADI.co.jp", []).email.should == "232323232323@BLUERADI.co.jp"
+      described_class.new("administration@example.museum", []).email.should == "administration@example.museum"
+    end
+
+    it "extracts email from a few tokens" do
+      described_class.new("sage akira@gmail.com fuge dage", []).email.should == "akira@gmail.com"
+    end
+
+    it "returns nil if no emails can be found" do
+      described_class.new("this is a pen", []).email.should == nil
+    end
+
+    it "returns nil if options field is empty" do
+      described_class.new(nil, []).email.should == nil
+      described_class.new('', []).email.should == nil
+    end
+  end
+
+  describe '#options' do
+    it 'returns tokens matching available options' do
+      described_class.new('sage foo@example.com', ['sage']).options.should == ['sage']
+    end
+
+    it 'returns empty array if nothing in raw options matches' do
+      described_class.new('sega', ['sage']).options.should == []
+    end
+  end
+end

--- a/spec/models/post/extension/sage_spec.rb
+++ b/spec/models/post/extension/sage_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Post::Extension::Sage do
+  let(:board) { FactoryGirl.create(:board) }
+  let(:topic) { FactoryGirl.create(:topic, board:board).reload }
+  let(:post) { FactoryGirl.create(:post, topic:topic) }
+
+  it 'does not bump' do
+    old_bumped_at = topic.bumped_at
+
+    Timecop.freeze(5.seconds.from_now) do
+      new_post = topic.posts.build
+      new_post.assign_attributes(content:'foo', options_raw:'sage')
+      new_post.save
+
+      topic.reload.bumped_at.should == old_bumped_at
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  before do
+    subject.stub(:board) { FactoryGirl.create(:board) }
+  end
+  describe '#options_raw=' do
+    it 'analyze value' do
+      subject.options_raw = 'sage sg-epk@jtk93.x29.jp'
+      subject.options.should include 'sage'
+      subject.email.should include 'sg-epk@jtk93.x29.jp'
+    end
+
+    it 'can handle empty string' do
+      subject.options_raw = ''
+      expect(subject.options.empty?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
* extract emails
* allow Post object extension
* add sage option

If one want to add other options like sage, create a class under the `Post::Extension`, and reference its underscore name in the config file.