### PR TITLE
Record image dimension

### DIFF
--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -1,7 +1,7 @@
 class ImagePresenter < LulalalaPresenter::Base
   def linked_display
     h.link_to(
-      h.image_tag(h.image_url(model.image.thumb.url)),
+      h.image_tag(h.image_url(model.image.thumb.url), width:model.thumb_width, height:model.thumb_height),
       h.image_url(model.image.url),
       class:'img'
     ).html_safe

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -36,7 +36,10 @@ class ImageUploader < CarrierWave::Uploader::Base
     process :remove_animation
     process :resize_to_fit => [250, 250]
     process :watermark
+    process :store_thumb_dimensions
   end
+
+  process :store_dimensions
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
@@ -85,6 +88,18 @@ class ImageUploader < CarrierWave::Uploader::Base
         img.collapse!
       end
       img
+    end
+  end
+
+  def store_dimensions
+    if file && model
+      model.width, model.height = ::MiniMagick::Image.open(file.file)[:dimensions]
+    end
+  end
+
+  def store_thumb_dimensions
+    if file && model
+      model.thumb_width, model.thumb_height = ::MiniMagick::Image.open(file.file)[:dimensions]
     end
   end
 end

--- a/db/migrate/20160327113357_add_width_and_height_to_images.rb
+++ b/db/migrate/20160327113357_add_width_and_height_to_images.rb
@@ -1,0 +1,10 @@
+class AddWidthAndHeightToImages < ActiveRecord::Migration
+  def change
+    change_table :images do |t|
+      t.integer :width, after: :image
+      t.integer :height, after: :width
+      t.integer :thumb_width, after: :height
+      t.integer :thumb_height, after: :thumb_width
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160320083647) do
+ActiveRecord::Schema.define(version: 20160327113357) do
 
   create_table "boards", force: :cascade, comment: "board" do |t|
     t.string   "seo_name",   limit: 255,   null: false, comment: "represent name in URL. Must be URL valid characters."
@@ -24,11 +24,15 @@ ActiveRecord::Schema.define(version: 20160320083647) do
   add_index "boards", ["seo_name"], name: "index_boards_on_seo_name", unique: true, using: :btree
 
   create_table "images", force: :cascade, comment: "image" do |t|
-    t.integer  "post_id",    limit: 4
-    t.string   "image",      limit: 255,              comment: "filename"
-    t.string   "remote_url", limit: 255,              comment: "url of image fetched from"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.integer  "post_id",      limit: 4
+    t.string   "image",        limit: 255,              comment: "filename"
+    t.integer  "width",        limit: 4
+    t.integer  "height",       limit: 4
+    t.integer  "thumb_width",  limit: 4
+    t.integer  "thumb_height", limit: 4
+    t.string   "remote_url",   limit: 255,              comment: "url of image fetched from"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
   add_index "images", ["post_id"], name: "index_images_on_post_id", using: :btree


### PR DESCRIPTION
This allows us to set img tag with width and height, preventing browser layout reflow.